### PR TITLE
add warning to conditioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ See user manual at
 [https://sensirion.github.io/python-i2c-sgp4x/](https://sensirion.github.io/python-i2c-sgp4x/).
 
 
+## SGP41 Conditioning
+
+After each restart of the SGP41 sensor or when the hotplates have been switched off, the conditioning command must
+be called from idle mode. The conditioning heats the hotplate of the NOx pixel to a different temperature compared
+to the measurement mode enabling a faster switch-on thereafter.
+
+It is recommended to execute the conditioning for 10s, but **10s must not be exceeded** to avoid damage to the sensing material.
+
+
 ## Development
 
 We develop and test this driver using our company internal tools (version

--- a/example_linux_sgp41.py
+++ b/example_linux_sgp41.py
@@ -9,7 +9,8 @@ with LinuxI2cTransceiver('/dev/i2c-1') as i2c_transceiver:
 
     print("SGP41 Serial Number: {}".format(sgp41.get_serial_number()))
 
-    # Run  conditioning for 10 seconds
+    # Run conditioning for 10 seconds
+    # WARNING: To avoid damage to the sensing material the conditioning must not exceed 10s!
     for _ in range(10):
         time.sleep(1)
         sraw_voc = sgp41.conditioning()

--- a/example_sensorbridge_sgp41.py
+++ b/example_sensorbridge_sgp41.py
@@ -23,7 +23,8 @@ with ShdlcSerialPort(port='COM1', baudrate=460800) as port:
 
     print("SGP41 Serial Number: {}".format(sgp41.get_serial_number()))
 
-    # Run  conditioning for 10 seconds
+    # Run conditioning for 10 seconds
+    # WARNING: To avoid damage to the sensing material the conditioning must not exceed 10s!
     for _ in range(10):
         time.sleep(1)
         sraw_voc = sgp41.conditioning()

--- a/sensirion_i2c_sgp4x/sgp41/device.py
+++ b/sensirion_i2c_sgp4x/sgp41/device.py
@@ -44,6 +44,8 @@ class Sgp41I2cDevice(I2cDevice):
         conditioning. This command returns only the measured raw signal of the VOC
         pixel SRAW_VOC
 
+        WARNING: To avoid damage to the sensing material the conditioning must not exceed 10s!
+
         :param relative_humidity: relative humidity in percent. Defaults to 50% RH
         :param temperature: temperature in degree celsius. Defaults to 25°C
         :return: raw VOC signal (:py:class:`~sensirion_i2c_sgp4x.sgp41.response_types.Sgp41SrawVoc`)


### PR DESCRIPTION
add warning to:
- Example Usages
- Function description (gets pulled into docs/quickstart)